### PR TITLE
feat: Implement map screen, bottom navigation, and location FAB

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,11 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app needs access to your location to show it on the map.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app needs access to your location to show it on the map and update it even when the app is in the background.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>This app needs access to your location to show it on the map.</string>
 </dict>
 </plist>

--- a/lib/map_screen.dart
+++ b/lib/map_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:maplibre_gl/maplibre_gl.dart';
+
+class MapScreen extends StatefulWidget {
+  const MapScreen({Key? key}) : super(key: key); // Accept and pass the key
+
+  @override
+  State<MapScreen> createState() => MapScreenState(); // Public State class
+}
+
+class MapScreenState extends State<MapScreen> { // Made public
+  MapLibreMapController? mapController;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  void _onMapCreated(MapLibreMapController controller) {
+    mapController = controller;
+  }
+
+  void _onStyleLoaded() {
+    // You can add a log or print statement here to confirm style loading
+    print('Style loaded');
+  }
+
+  // Public method to animate camera
+  void animateToLocation(LatLng target) {
+    mapController?.animateCamera(
+      CameraUpdate.newLatLngZoom(target, 14.0), // Zoom level can be adjusted
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // The Scaffold and AppBar were part of the example, but for a screen
+    // that's embedded in another Scaffold (like in main.dart), it might
+    // not need its own Scaffold/AppBar.
+    // For now, keeping it as is, but this could be refactored.
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('MapLibre GL'),
+      ),
+      body: MapLibreMap(
+        styleString: 'https://map.witel.ir/styles/bright/style.json',
+        initialCameraPosition: const CameraPosition(
+          target: LatLng(35.6892, 51.3890), // Default to Tehran, Iran
+          zoom: 12.0,
+        ),
+        onMapCreated: _onMapCreated,
+        onStyleLoadedCallback: _onStyleLoaded,
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   maplibre_gl: ^0.22.0
   geolocator: ^14.0.1
   flutter_bloc: ^9.1.1
+  permission_handler: ^11.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Adds a bottom navigation bar with two tabs:
1. A Map screen displaying a MapLibre GL map with a specified style.
2. The original counter screen.

A FloatingActionButton is added to the Map screen. When tapped:
- It requests location permissions from you.
- Fetches the current device location.
- Animates the map to center on your location.
- Provides you feedback via SnackBars for permission status and errors.

Includes:
- Necessary dependencies: `permission_handler`, `maplibre_gl`, `geolocator`.
- Android and iOS permission configurations for location services.
- Error handling for location services and permissions.